### PR TITLE
Add salary conversions

### DIFF
--- a/poscUnits22.xml
+++ b/poscUnits22.xml
@@ -58,6 +58,44 @@
   </DocumentInformation>
 
   <UnitsDefinition>
+        <UnitOfMeasure id="$Py" annotation="dpy">
+      <Name>$/year</Name>
+      <QuantityType>dollar per time</QuantityType>
+      <DimensionalClass>1/T</DimensionalClass>
+      <BaseUnit/>
+    </UnitOfMeasure>
+    <UnitOfMeasure id="$Ph" annotation="dph">
+      <Name>$/hour</Name>
+      <QuantityType>dollar per time</QuantityType>
+      <DimensionalClass>1/T</DimensionalClass>
+      <ConversionToBaseUnit baseUnit="dpy">
+        <Factor>2087</Factor>
+      </ConversionToBaseUnit>
+    </UnitOfMeasure>
+    <UnitOfMeasure id="$Pm" annotation="dpm">
+      <Name>$/month</Name>
+      <QuantityType>dollar per time</QuantityType>
+      <DimensionalClass>1/T</DimensionalClass>
+      <ConversionToBaseUnit baseUnit="dpy">
+        <Factor>12</Factor>
+      </ConversionToBaseUnit>
+    </UnitOfMeasure>
+    <UnitOfMeasure id="$Pd" annotation="dpd">
+      <Name>$/work day</Name>
+      <QuantityType>dollar per time</QuantityType>
+      <DimensionalClass>1/T</DimensionalClass>
+      <ConversionToBaseUnit baseUnit="dpy">
+        <Factor>261</Factor>
+      </ConversionToBaseUnit>
+    </UnitOfMeasure>
+    <UnitOfMeasure id="$Pw" annotation="dpw">
+      <Name>$/week</Name>
+      <QuantityType>dollar per time</QuantityType>
+      <DimensionalClass>1/T</DimensionalClass>
+      <ConversionToBaseUnit baseUnit="dpy">
+        <Factor>52</Factor>
+      </ConversionToBaseUnit>
+    </UnitOfMeasure>
 
     <UnitOfMeasure id="1PH" annotation="1/H">
       <Name>inverse henry</Name>


### PR DESCRIPTION
Adds $/year and associated units for quickly converting between different ways of quoting pay.

I find the thing I most frequently use different units for is dollars per time. Pay rates are frequently quoted hourly, monthly and yearly. I added this to my personal XML file and have found it quite useful, I imagine others might as well.

@WoLpH 