### PR TITLE
Change the hardcoded log path

### DIFF
--- a/converter/main.py
+++ b/converter/main.py
@@ -99,7 +99,7 @@ def scriptfilter(items, query):
 
 
 if __name__ == '__main__':
-    with open('/Users/rick/workspace/alfred-converter/log.txt', 'a') as fh:
+    with open('/tmp/alfred-converter-log.txt', 'a') as fh:
         import pprint
         pprint.pprint(os.environ, stream=fh)
         print(sys.argv, file=fh)


### PR DESCRIPTION
I would at least change the hardcoded path to the log to something more reasonable. Since it's a log and I don't see why it should be permanent why not use the `tmp`.