### PR TITLE
Make miles an alias for mile

### DIFF
--- a/converter/constants.py
+++ b/converter/constants.py
@@ -76,6 +76,7 @@ ANNOTATION_REPLACEMENTS = {
 
 EXPANSIONS = {
     'foot': ('feet', 'ft'),
+    'mile': ('miles',),
     'mili': ('milli',),
     'meter': ('metres', 'meter', 'meters'),
     '^2': ('sq', 'square'),


### PR DESCRIPTION
Hi,

If I enter, say "3 mile", alfred-converter will show conversions, but the conversions disappear if I enter "3 miles". This PR adds an expansion for "miles" similar to "feet" or "meters".

Perhaps there are other units that could use this expansion as well? Miles is the one I ran into, however.