### PR TITLE
Add unit aliases to keyword matches

### DIFF
--- a/converter/convert.py
+++ b/converter/convert.py
@@ -347,7 +347,11 @@ class Unit(object):
         if keyword:
             new_tos = []
             for to in tos:
-                if keyword in to.name or keyword in to.id:
+                if (
+                    keyword in to.name
+                    or keyword in to.id
+                    or keyword in to.annotations
+                ):
                     new_tos.append(to)
 
             if new_tos:


### PR DESCRIPTION
Hi again,

If I enter "10 pounds to ounce", I only see one result, "160 ounce mass". However, if I enter "100 pounds to ounces", I see all units instead of just ounces. This seems to be because the `Unit.others(self, keyword=None)` function does not check for keyword matches to unit aliases (annotations) before outputting the full list of units.
This also applies to other units with aliases (foot/feet, lb/lbs, litre/liter/liters, gigabyte/GB, etc.).

This PR adds to `Unit.others()` a check for an exact match of the keyword to any of the annotations when generating the filtered list `new_tos`.