### PR TITLE
Filter the denominators that can be shown for fractional units

### DIFF
--- a/converter/constants.py
+++ b/converter/constants.py
@@ -6,6 +6,7 @@ UNITS_PICKLE_FILE = 'units.pickle'
 
 OUTPUT_DECIMALS = 6
 DECIMAL_SEPARATOR = os.environ.get('DECIMAL_SEPARATOR') or '.'
+ALLOWED_DENOMINATORS = set(range(10)) | {16, 32, 64, 100}
 
 SOURCE_PATTERN = r'^(?P<quantity>.*[\d.]+)\s*(?P<from>[^\d\s]([^\s]*|.+?))'
 SOURCE_RE = re.compile(SOURCE_PATTERN + '$', re.IGNORECASE | re.VERBOSE)

--- a/converter/convert.py
+++ b/converter/convert.py
@@ -499,8 +499,12 @@ def main(units, query, create_item):
             if to.fractional:
                 new_magnitude = fraction_to_decimal(new_quantity).copy_abs() \
                     .log10()
-                new_quantity = fraction_to_string(new_quantity)
-                new_quantity_proper = fraction_to_string(new_quantity, True)
+                if new_quantity.denominator in constants.ALLOWED_DENOMINATORS:
+                    new_quantity = fraction_to_string(new_quantity)
+                    new_quantity_proper = fraction_to_string(new_quantity, True)
+                else:
+                    new_quantity = decimal_to_string(fraction_to_decimal(new_quantity))
+                    new_quantity_proper = None
             else:
                 new_magnitude = new_quantity.copy_abs().log10()
                 new_quantity = decimal_to_string(new_quantity)
@@ -541,17 +545,18 @@ def main(units, query, create_item):
                     minor = minor_quantity
                 minor_proper = fraction_to_string(minor, True)
 
-                titles.append('%s %s = %s %s %s %s' % (
-                    swap_unit(left, from_, quantity)
-                    + swap_unit(left, to, major)
-                    + swap_unit(left, split, minor)
-                ))
-                if minor_proper:
+                if minor.denominator in constants.ALLOWED_DENOMINATORS:
                     titles.append('%s %s = %s %s %s %s' % (
                         swap_unit(left, from_, quantity)
                         + swap_unit(left, to, major)
-                        + swap_unit(left, split, minor_proper)
+                        + swap_unit(left, split, minor)
                     ))
+                    if minor_proper:
+                        titles.append('%s %s = %s %s %s %s' % (
+                            swap_unit(left, from_, quantity)
+                            + swap_unit(left, to, major)
+                            + swap_unit(left, split, minor_proper)
+                        ))
 
             for title in titles:
                 yield create_item(


### PR DESCRIPTION
This PR filters the denominators that can be shown for fractional units, showing decimals otherwise. While units like inches are commonly written as fractions, e.g., "5/8 inch", large denominators are uncommon.

For example, "57 mm to in" currently produces the response "57 millimeters = 285/127 inch", which I don't find very helpful. This PR changes the output to "57 millimeters = 2.244094 inch". 

It also changes split units, for example "1357 mm to ft"  outputs "1357 millimeters = 4.4521 foot" instead of:
> 1357 millimeters = 6785/1524 foot
> 1357 millimeters = 4 689/1524 foot
> 1357 millimeters = 4 foot 689/127 inch
> 1357 millimeters = 4 foot 5 54/127 inch

Split units with allowed denominators still work, for example "113.125 in to ft" gives:
> 113.125 inch = 9.427083 foot
> 113.125 inch = 9 foot 41/8 inch
> 113.125 inch = 9 foot 5 1/8 inch

instead of:
> 113.125 inch = 905/96 foot
> 113.125 inch = 9 41/96 foot
> 113.125 inch = 9 foot 41/8 inch
> 113.125 inch = 9 foot 5 1/8 inch

And "113 in to ft" gives:
> 113 inch = 9.416667 foot
> 113 inch = 9 foot 5 inch

instead of:
> 113/12 foot
> 113 inch = 9 5/12 foot
> 113 inch = 9 foot 5 inch

Note that the denominator 12 is excluded as the inches split unit is more useful anyways.

An alternate solution would be to append the decimal as an additional output, but I think that would clutter the results, and denominators like 96 or 127 probably aren't useful to many people anyway.

The `ALLOWED_DENOMINATORS` set is just an initial thought, so I'm open to additions or removals. 