### PR TITLE
Fix log10 and add log2 functions

### DIFF
--- a/converter/constants.py
+++ b/converter/constants.py
@@ -236,6 +236,7 @@ MATH_FUNCTIONS = [
     'log',
     'log1p',
     'log10',
+    'log2',
     'pow',
     'sqrt',
     # Trigonometric functions

--- a/converter/safe_math.py
+++ b/converter/safe_math.py
@@ -139,7 +139,7 @@ safe_dict['sin'] = sin
 safe_dict['inf'] = decimal.Decimal('Inf')
 safe_dict['infinity'] = decimal.Decimal('Inf')
 
-DECIMAL_RE = re.compile(r'(\d*\.\d+|\d+\.?)')
+DECIMAL_RE = re.compile(r'(?<![a-zA-Z0-9])(\d*\.\d+|\d+\.?)')
 DECIMAL_REPLACE = r'Decimal("\g<1>")'
 
 AUTOMUL_RE = re.compile(r'\)\s*(\w+)')

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -24,6 +24,8 @@ EXPRESSIONS = {
     '16"': 'inch 16 = foot 1 inch 4',
     'log(10, 10)': '1',
     'log(100) / log(10)': '2',
+    'log10(100)': '2',
+    'log2(16)': '4',
     '0f': 'degree Fahrenheit 0 = degree Fahrenheit -0',
     '113 in to ft': 'inch 113 = foot 9 inch 5',
     '100 pounds to ounces': 'pounds mass 100 = ounce mass 1600',


### PR DESCRIPTION
The query "log10(<number>)" was broken, as the "log10" string was being converted to "logDecimal(10)" in `safe_eval()`: https://github.com/wolph/alfred-converter/blob/49f3053932ee4ef13cecdeccc030fa52e5cab4b9/converter/safe_math.py#L209
Thus, the resulting query was "logDecimal(10)(<number>)", which produced an error.

This PR prevents replacement of numbers in function names with `Decimal`s, using a negative look-behind to remove decimal matches immediately preceded by letters or numbers. It also adds the `math.log2()` function.