### PR TITLE
Fix base units not being set

### DIFF
--- a/converter/convert.py
+++ b/converter/convert.py
@@ -132,7 +132,7 @@ class Units(object):
 
             base = base_unit.get('baseUnit')
         else:
-            base = elem.get('id')
+            base = None
 
         return base, (a, b, c, d)
 
@@ -152,7 +152,7 @@ class Units(object):
             name=name,
             annotations=annotations,
             quantity_types=get_texts(elem, 'QuantityType'),
-            base_unit=get_text(elem, 'BaseUnit'),
+            base_unit=base_unit,
             conversion_params=conversion_params,
         )
 

--- a/converter/extra_units.py
+++ b/converter/extra_units.py
@@ -105,3 +105,8 @@ def register_post(units):
             annotations=[prefix + 'f' for prefix in prefixes] + [id, name],
             conversion_params=tuple(map(str, (0, multiplier, 1, 0))),
         ).register(units)
+
+    hz = units.get("Hz")
+    hz.conversion_params = tuple(units.get('cycles/second').conversion_params)
+    hz.base_unit = 'radians/second'
+    hz.register(units)


### PR DESCRIPTION
For example millihertz was listed in `units.base_units` because its `base_unit` was set to None, and the unit wasn't picked up from `<ConversionToBaseUnit>`.

Also fixes the erroneous conversion `1 Hz = 6.283185 counts/second` by giving hertz the base unit 6.283185 radians/second, the same as 1 c/s. (Note that mHz and all other scales of Hz are already based on radians/second.)