### PR TITLE
Sort conversions by result magnitude

### DIFF
--- a/converter/convert.py
+++ b/converter/convert.py
@@ -460,21 +460,20 @@ def change_decimal(function):
 
 
 
-def sort_magnitude_difference(result):
+def sort_abs_magnitude(result):
     from_, quantity, to = result
     if from_ == to:
         return infinity
     base_quantity: _FractionDecimalStr = from_.to_base(quantity)
     new_quantity: _FractionDecimalStr = to.from_base(base_quantity)
-    magnitude: decimal.Decimal = quantity.copy_abs().log10()
     if to.fractional:
         new_magnitude = fraction_to_decimal(new_quantity).copy_abs().log10()
     elif isinstance(new_quantity, decimal.Decimal):
         new_magnitude = new_quantity.copy_abs().log10()
     else:
         return infinity
-    magnitude_difference = abs(magnitude - new_magnitude)
-    return magnitude_difference
+    abs_magnitude = abs(new_magnitude)
+    return abs_magnitude
 
 
 def main(units: Units, query: str, create_item):
@@ -484,7 +483,7 @@ def main(units: Units, query: str, create_item):
     max_magnitude = get_max_magnitude()
 
     result = list(units.convert(query))
-    result.sort(key=sort_magnitude_difference)
+    result.sort(key=sort_abs_magnitude)
     for from_, quantity, to in result:
         if to and to.is_blacklisted():  # pragma: no cover
             continue

--- a/converter/convert.py
+++ b/converter/convert.py
@@ -462,7 +462,7 @@ def change_decimal(function):
 
 def sort_abs_magnitude(result):
     from_, quantity, to = result
-    if from_ == to:
+    if not from_ or not to or from_ == to:
         return infinity
     base_quantity: _FractionDecimalStr = from_.to_base(quantity)
     new_quantity: _FractionDecimalStr = to.from_base(base_quantity)

--- a/converter/convert.py
+++ b/converter/convert.py
@@ -459,20 +459,26 @@ def change_decimal(function):
     return _change_decimal
 
 
-
 def sort_abs_magnitude(result):
     from_, quantity, to = result
+
     if not from_ or not to or from_ == to:
         return infinity
+
     base_quantity: _FractionDecimalStr = from_.to_base(quantity)
     new_quantity: _FractionDecimalStr = to.from_base(base_quantity)
+
     if to.fractional:
-        new_magnitude = fraction_to_decimal(new_quantity).copy_abs().log10()
+        abs_decimal_value = fraction_to_decimal(new_quantity).copy_abs()
     elif isinstance(new_quantity, decimal.Decimal):
-        new_magnitude = new_quantity.copy_abs().log10()
+        abs_decimal_value = new_quantity.copy_abs()
     else:
         return infinity
-    abs_magnitude = abs(new_magnitude)
+
+    if abs_decimal_value.is_zero():
+        return infinity
+
+    abs_magnitude = abs(abs_decimal_value.log10())
     return abs_magnitude
 
 

--- a/converter/convert.py
+++ b/converter/convert.py
@@ -459,13 +459,33 @@ def change_decimal(function):
     return _change_decimal
 
 
+
+def sort_magnitude_difference(result):
+    from_, quantity, to = result
+    if from_ == to:
+        return infinity
+    base_quantity: _FractionDecimalStr = from_.to_base(quantity)
+    new_quantity: _FractionDecimalStr = to.from_base(base_quantity)
+    magnitude: decimal.Decimal = quantity.copy_abs().log10()
+    if to.fractional:
+        new_magnitude = fraction_to_decimal(new_quantity).copy_abs().log10()
+    elif isinstance(new_quantity, decimal.Decimal):
+        new_magnitude = new_quantity.copy_abs().log10()
+    else:
+        return infinity
+    magnitude_difference = abs(magnitude - new_magnitude)
+    return magnitude_difference
+
+
 def main(units: Units, query: str, create_item):
     create_item = change_decimal(create_item)
     query = clean_query(query)
     left = get_units_left()
     max_magnitude = get_max_magnitude()
 
-    for from_, quantity, to in units.convert(query):
+    result = list(units.convert(query))
+    result.sort(key=sort_magnitude_difference)
+    for from_, quantity, to in result:
         if to and to.is_blacklisted():  # pragma: no cover
             continue
 


### PR DESCRIPTION
This PR sorts conversions to prioritize the results that are closest to 0 in log-space.

While alfred-converter reduces unhelpful conversions with a limit on the maximum magnitude difference between the `from_` and `to` units, I think it's actually better to sort based on the magnitude of the resulting conversion.

Screenshots:
Before, the conversion of `100 s` did not show the conversion to minutes in the top 9.
<img width="718" alt="Screenshot 2025-05-31 at 11 12 49 PM" src="https://github.com/user-attachments/assets/b1037f13-68b0-4223-b390-86bb9b0e4472" />

After, `100 second = 1.66666667 minutes` is the top result.
<img width="718" alt="Screenshot 2025-06-01 at 12 21 21 AM" src="https://github.com/user-attachments/assets/7aeb8f56-4953-4ccb-93de-96c20d457c10" />
(note that I've removed some obscure time units that popped up in the second screenshot: the "hundred second" and the "ten milli second")