### PR TITLE
Exclude rarely used time units

### DIFF
--- a/converter/constants.py
+++ b/converter/constants.py
@@ -139,6 +139,9 @@ ANNOTATION_BLACKLIST = {
     'ftBnB',
     'ftCla',
     'ftInd',
+    'cs',
+    'hs',
+    '100ka',
 }
 
 NAME_BLACKLIST = {


### PR DESCRIPTION
Excludes the centisecond, hectosecond, and 100ka.

These units have strange names that make them redundant with existing units:
- "ten milli second" is redundant with "millisecond"
- "hundred second" is redundant with "second" and much less common than "minute"
- "100000 years" is redundant with years, and it's strange that 100ka exists but not 1ka.

So say "200 s" would be converted to "2 hundred seconds", and "0.02 s" would be converted to "2 ten milli second".

See also:
https://english.stackexchange.com/questions/79768/what-do-you-call-one-hundredth-of-a-second
https://www.reddit.com/r/answers/comments/1p0tc9/why_are_hundredths_of_a_second_commonly_referred/